### PR TITLE
feat: implement dual R2 credentials management with chain commitments

### DIFF
--- a/chain.py
+++ b/chain.py
@@ -1,0 +1,410 @@
+# The MIT License (MIT)
+# © 2025 tplr.ai
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+# documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+# and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+# the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+# THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+# OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+# DEALINGS IN THE SOFTWARE.
+# type: ignore
+
+# Global imports
+import asyncio
+from collections import defaultdict
+from types import SimpleNamespace
+
+import bittensor as bt
+import numpy as np
+import torch
+from bittensor import Wallet
+from bittensor.core.chain_data import decode_account_id
+from pydantic import ValidationError
+
+# Local imports
+from .logging import logger
+from .schemas import Bucket
+
+
+class ChainManager:
+    """Base class for handling chain interactions."""
+
+    def __init__(
+        self,
+        config,
+        hparams=None,
+        fetch_interval: int = 600,  # Fetch interval in seconds
+        wallet: bt.wallet | None = None,
+        bucket: Bucket | None = None,
+    ):
+        """
+        Initialize chain commitment handler.
+
+        Args:
+            config: Bittensor config object.
+            hparams: Hyperparameters namespace containing model configuration.
+            fetch_interval (int): Interval in seconds between fetching commitments.
+            wallet (bt.wallet, optional): Wallet to sign commitments.
+            bucket (Bucket, optional): Bucket configuration to commit.
+        """
+        self.config = config
+        self.netuid = self.config.netuid
+        self.hparams = hparams or SimpleNamespace()
+
+        # Bittensor objects
+        self.subtensor = bt.subtensor(config=self.config)
+        self.metagraph = self.subtensor.metagraph(self.netuid)
+
+        # Block and window tracking
+        self.current_block = 0
+        self.current_window = 0
+        self.window_duration = self.hparams.blocks_per_window
+        self.window_time = 0
+        self.window_seeds = {}
+
+        # Events
+        self.block_event = asyncio.Event()
+        self.new_window_event = asyncio.Event()
+
+        # Initialize bucket storage
+        self.commitments = {}
+        self.peers = []
+        self.eval_peers = defaultdict(int)
+        self.fetch_interval = fetch_interval
+        self._fetch_task = None
+
+        # Store wallet and bucket
+        self.wallet = wallet
+        self.bucket = bucket
+
+    def start_commitment_fetcher(self):
+        """Attach to the already-running event loop."""
+        if self._fetch_task is None:
+            self._fetch_task = asyncio.create_task(
+                self._fetch_commitments_periodically()
+            )
+
+    async def _fetch_commitments_periodically(self):
+        """Background task to periodically fetch commitments."""
+        while True:
+            try:
+                # Create new subtensor instance for metagraph sync
+                await asyncio.to_thread(
+                    lambda: self.metagraph.sync(subtensor=self.subtensor)
+                )
+
+                # Create new subtensor instance for commitments
+                commitments = await self.get_commitments()
+                if commitments:
+                    self.commitments = commitments
+                    logger.debug(f"Updated commitments: {self.commitments}")
+            except Exception as e:
+                logger.error(f"Error fetching commitments: {e}")
+                self.subtensor.substrate.close()
+                self.subtensor.substrate.initialize()
+            await asyncio.sleep(self.fetch_interval)
+
+    def get_bucket(self, uid: int) -> Bucket | None:
+        """Helper function to get the bucket for a given UID.
+
+        Args:
+            uid (int): The UID to retrieve the bucket for.
+
+        Returns:
+            Optional[Bucket]: The bucket corresponding to the UID, or None if not found.
+        """
+        return self.commitments.get(uid)
+
+    def get_all_buckets(self) -> dict[int, Bucket | None]:
+        """Helper function to get all buckets for all UIDs in the metagraph.
+
+        Returns:
+            Dict[int, Optional[Bucket]]: Mapping of UIDs to their bucket configurations
+        """
+        return {uid: self.get_bucket(uid) for uid in self.metagraph.uids}
+
+    def commit(self, wallet: "bt.wallet", bucket: Bucket) -> None:
+        """Commits bucket configuration to the chain.
+
+        Args:
+            wallet (bt.wallet): Wallet to sign the commitment
+            bucket (Bucket): Bucket configuration to commit
+        """
+        concatenated = (
+            bucket.account_id + bucket.access_key_id + bucket.secret_access_key
+        )
+        if self.netuid is not None:
+            self.subtensor.commit(wallet, self.netuid, concatenated)
+            logger.info(
+                f"Committed bucket configuration to chain for hotkey {wallet.hotkey.ss58_address}"
+            )
+
+    def try_commit(self, wallet: Wallet, bucket: Bucket) -> None:
+        """Attempts to verify existing commitment matches current bucket config and commits if not.
+
+        Args:
+            wallet (bt.wallet): Wallet to sign the commitment
+            bucket (Bucket): Current bucket configuration to verify/commit
+        """
+        try:
+            # Get existing commitment
+            commitment = self.get_commitment(
+                self.metagraph.hotkeys.index(wallet.hotkey.ss58_address)
+            )
+
+            # Convert Bucket objects to concatenated strings for comparison
+            commitment_str = (
+                commitment.name
+                + commitment.access_key_id
+                + commitment.secret_access_key
+            )
+            bucket_details_from_env = (
+                bucket.name + bucket.access_key_id + bucket.secret_access_key
+            )
+
+            logger.debug(
+                "Comparing current commitment to bucket details from the environment:\n"
+                f"Commitment: {commitment_str}\n"
+                f"Current: {bucket_details_from_env}"
+            )
+
+            if bucket_details_from_env != commitment_str:
+                if commitment_str == "":
+                    log_msg_base = "Commitment is empty, likely because you're running your miner for the first time"
+                else:
+                    log_msg_base = "Bucket details have changed"
+                logger.info(f"{log_msg_base}. Committing the new details.")
+                self.commit(wallet, bucket)
+
+        except Exception as e:
+            logger.error(
+                f"Error while verifying commitment: {str(e)}\n"
+                "Committing the bucket details from the environment."
+            )
+            self.subtensor.substrate.close()
+            self.subtensor.substrate.initialize()
+            self.commit(wallet, bucket)
+
+    def get_commitment(self, uid: int) -> Bucket:
+        """Retrieves and parses committed bucket configuration data for a given
+        UID.
+
+        This method fetches commitment data for a specific UID from the
+        subtensor network and decodes it into a structured format. The
+        retrieved data is split into the following fields:
+        - Account ID: A string of fixed length 32 characters.
+        - Access key ID: A string of fixed length 32 characters.
+        - Secret access key: A string of variable length (up to 64 characters).
+
+        The parsed fields are then mapped to an instance of the `Bucket` class.
+        When initializing the Bucket object, the account ID is also used as the
+        bucket name.
+
+        The retrieval process involves:
+        - Fetching the commitment data for the specified UID using the
+          configured `netuid` from the subtensor network.
+        - Splitting the concatenated string into individual fields based on
+          their expected lengths and order.
+        - Mapping the parsed fields to a `Bucket` instance.
+
+        **Note:** The order of fields (bucket name, account ID, access key ID,
+        secret access key) in the concatenated string is critical for accurate
+        parsing.
+
+        Args:
+            uid: The UID of the neuron whose commitment data is being
+                retrieved.
+
+        Returns:
+            Bucket: An instance of the `Bucket` class containing the parsed
+                bucket configuration details.
+
+        Raises:
+            ValueError: If the parsed data does not conform to the expected
+                format for the `Bucket` class.
+            Exception: If an error occurs while retrieving the commitment data
+                from the subtensor network.
+        """
+
+        try:
+            concatenated = self.subtensor.get_commitment(self.netuid, uid)
+            logger.info(f"Commitment fetched: {concatenated}")
+        except Exception as e:
+            raise Exception(f"Couldn't get commitment from uid {uid} because {e}")
+        if len(concatenated) != 128:
+            raise ValueError(
+                f"Commitment '{concatenated}' is of length {len(concatenated)} but should be of length 128."
+            )
+
+        try:
+            return Bucket(
+                name=concatenated[:32],
+                account_id=concatenated[:32],
+                access_key_id=concatenated[32:64],
+                secret_access_key=concatenated[64:],
+            )
+        except ValidationError as e:
+            raise ValueError(f"Invalid data in commitment: {e}")
+
+    def decode_metadata(self, encoded_ss58: tuple, metadata: dict) -> tuple[str, str]:
+        # Decode the key into an SS58 address.
+        decoded_key = decode_account_id(encoded_ss58[0])
+        # Get the commitment from the metadata.
+        commitment = metadata["info"]["fields"][0][0]
+        bytes_tuple = commitment[next(iter(commitment.keys()))][0]
+        return decoded_key, bytes(bytes_tuple).decode()
+
+    async def get_commitments(self, block: int | None = None) -> dict[int, Bucket]:
+        """Retrieves all bucket commitments from the chain.
+
+        Args:
+            block (int, optional): Block number to query at
+
+        Returns:
+            Dict[int, Bucket]: Mapping of UIDs to their bucket configurations
+        """
+        try:
+            substrate = self.subtensor.substrate
+            # Query commitments via substrate.query_map
+            query_result = substrate.query_map(
+                module="Commitments",
+                storage_function="CommitmentOf",
+                params=[self.netuid],
+                block_hash=None if block is None else substrate.get_block_hash(block),
+            )
+
+            hotkey_to_uid = dict(zip(self.metagraph.hotkeys, self.metagraph.uids))
+            commitments = {}
+
+            for key, value in query_result:
+                try:
+                    decoded_ss58, commitment_str = self.decode_metadata(
+                        key, value.value
+                    )
+                except Exception as e:
+                    logger.error(f"Failed to decode metadata for key {key.value}: {e}")
+                    continue
+
+                if decoded_ss58 not in hotkey_to_uid:
+                    continue
+
+                uid = hotkey_to_uid[decoded_ss58]
+                if len(commitment_str) != 128:
+                    logger.error(
+                        f"Invalid commitment length for UID {uid}: {len(commitment_str)}"
+                    )
+                    continue
+
+                try:
+                    bucket = Bucket(
+                        name=commitment_str[:32],
+                        account_id=commitment_str[:32],
+                        access_key_id=commitment_str[32:64],
+                        secret_access_key=commitment_str[64:],
+                    )
+                    commitments[uid] = bucket
+                    logger.debug(f"Retrieved bucket commitment for UID {uid}")
+                except Exception as e:
+                    logger.error(f"Failed to build bucket for UID {uid}: {e}")
+                    continue
+
+            return commitments
+        except Exception:
+            self.subtensor.substrate.close()
+            self.subtensor.substrate.initialize()
+            return
+
+    async def get_bucket_for_neuron(self, wallet: "bt.wallet") -> Bucket | None:
+        """Get bucket configuration for a specific neuron's wallet
+
+        Args:
+            wallet (bt.wallet): The wallet to get bucket for
+
+        Returns:
+            Optional[Bucket]: The bucket assigned to this neuron, or None if not found
+        """
+        try:
+            # Get UID by finding hotkey's index in metagraph
+            uid = self.metagraph.hotkeys.index(wallet.hotkey.ss58_address)
+            return self.get_bucket(uid)
+        except ValueError:
+            logger.warning(
+                f"Hotkey {wallet.hotkey.ss58_address} not found in metagraph"
+            )
+            return None
+
+    async def fetch_commitments(self):
+        """Fetches commitments and updates self.commitments."""
+        commitments = await self.get_commitments()
+        if commitments:
+            self.commitments = commitments
+            logger.debug(f"Fetched commitments: {self.commitments}")
+        else:
+            logger.warning("No commitments fetched.")
+
+    def get_hotkey(self, uid: int) -> str | None:
+        """Returns the hotkey for a given UID."""
+        # Handle different data types for uids
+        if isinstance(self.metagraph.uids, (np.ndarray, torch.Tensor)):
+            uids_list = self.metagraph.uids.tolist()
+        else:
+            uids_list = self.metagraph.uids
+
+        # Handle different data types for hotkeys
+        if isinstance(self.metagraph.hotkeys, (np.ndarray, torch.Tensor)):
+            hotkeys_list = self.metagraph.hotkeys.tolist()
+        else:
+            hotkeys_list = self.metagraph.hotkeys
+
+        if uid in uids_list:
+            index = uids_list.index(uid)
+            return hotkeys_list[index]
+        else:
+            return None
+
+    def update_peers_with_buckets(self):
+        """Updates peers for gradient gathering, evaluation peers, and tracks inactive peers."""
+        # Create mappings
+        uid_to_stake = dict(
+            zip(self.metagraph.uids.tolist(), self.metagraph.S.tolist())
+        )
+
+        # Get currently active peers
+        active_peers = set(int(uid) for uid in self.active_peers)
+
+        # Track inactive peers (previously active peers that are no longer active)
+        previously_active = set(
+            self.eval_peers.keys()
+        )  # since self.eval_peers is now a dict
+        newly_inactive = previously_active - active_peers
+        self.inactive_peers = newly_inactive
+
+        logger.debug(f"Active peers: {active_peers}")
+        logger.info(f"Newly inactive peers: {newly_inactive}")
+        logger.debug(f"Stakes: {uid_to_stake}")
+
+        if not active_peers:
+            logger.warning("No active peers found. Skipping update.")
+            return
+
+        # ---------------------------------------------------------------
+        # Convert self.eval_peers into a dict while retaining old counts
+        # for peers still active with stake <= 1000.
+        # ---------------------------------------------------------------
+        self.eval_peers = {
+            int(uid): self.eval_peers.get(int(uid), 1)
+            for uid in active_peers
+            if uid in uid_to_stake and uid_to_stake[uid] <= 20000
+        }
+
+        logger.debug(f"Filtered eval peers: {list(self.eval_peers.keys())}")
+
+        logger.info(f"Total evaluation peers: {len(self.eval_peers)}")
+        logger.info(f"Total inactive peers: {len(self.inactive_peers)}")

--- a/docs/r2_credentials_design.md
+++ b/docs/r2_credentials_design.md
@@ -1,0 +1,289 @@
+# R2 Credentials Management Design for GRAIL
+
+## Overview
+
+This document outlines the design for implementing a dual-credential system for R2 (Cloudflare R2 or compatible S3 storage) in the GRAIL codebase. The system uses the same bucket and account but with different access credentials:
+
+1. **Read Credentials**: Read-only access keys posted to the chain as commitments, shared with everyone for reading rollout data
+2. **Write Credentials**: Read-write access keys stored locally, used by miners/validators to write to their buckets
+
+## Current State Analysis
+
+### Existing R2 Integration
+- GRAIL currently uses environment variables for R2 credentials:
+  - `R2_ACCOUNT_ID`: Account identifier for R2
+  - `R2_WRITE_ACCESS_KEY_ID`: Write access key
+  - `R2_WRITE_SECRET_ACCESS_KEY`: Write secret key
+  - `R2_BUCKET_ID`: Bucket identifier
+- All operations use the same write credentials
+- No chain commitment mechanism exists currently
+
+### Example Implementation Reference
+The provided `chain.py` and `schema.py` files demonstrate:
+- `ChainManager` class for managing chain interactions
+- `Bucket` schema with fields: name, account_id, access_key_id, secret_access_key
+- Commitment mechanism to post bucket info to chain
+- Periodic fetching of commitments from chain
+- Verification that local config matches chain commitment
+
+## Proposed Design
+
+### 1. Data Structures
+
+#### Bucket Schema Extension
+```python
+# grail/shared/schemas.py
+class BucketCredentials(BaseModel):
+    """Dual credential configuration for R2 buckets
+    
+    Same bucket and account, but different access keys:
+    - Read credentials: read-only access (shared on chain)
+    - Write credentials: read-write access (kept private)
+    """
+    
+    # Shared bucket configuration
+    bucket_name: str
+    account_id: str
+    
+    # Read-only credentials (shared on chain)
+    read_access_key_id: str
+    read_secret_access_key: str
+    
+    # Read-write credentials (local only, never shared)
+    write_access_key_id: str
+    write_secret_access_key: str
+    
+    @property
+    def read_commitment(self) -> str:
+        """Generate commitment string for chain (128 chars total)"""
+        # Truncate/pad to exactly 32 chars each for 128 total
+        return (
+            self.bucket_name[:32].ljust(32) +
+            self.read_access_key_id[:32].ljust(32) +
+            self.read_secret_access_key[:64].ljust(64)
+        )
+```
+
+### 2. Chain Management Integration
+
+#### Enhanced ChainManager
+```python
+# grail/infrastructure/chain.py
+class GrailChainManager:
+    """GRAIL-specific chain manager extending the base ChainManager"""
+    
+    def __init__(self, config, wallet, credentials: BucketCredentials):
+        self.credentials = credentials
+        self.wallet = wallet
+        self.config = config
+        self.netuid = config.netuid
+        self.subtensor = bt.subtensor(config=config)
+        self.metagraph = self.subtensor.metagraph(self.netuid)
+        
+        # Commitment tracking
+        self.commitments = {}  # uid -> read_credentials
+        self.fetch_interval = 600  # 10 minutes
+        self._fetch_task = None
+        
+    async def initialize(self):
+        """Initialize chain manager and verify/commit credentials"""
+        # Fetch existing commitments
+        await self.fetch_commitments()
+        
+        # Check if our commitment matches what's on chain
+        try:
+            uid = self.metagraph.hotkeys.index(self.wallet.hotkey.ss58_address)
+            existing = self.commitments.get(uid)
+            
+            if not existing or existing != self.credentials.read_commitment:
+                logger.info("Committing new read credentials to chain")
+                self.commit_read_credentials()
+        except ValueError:
+            logger.warning("Hotkey not found in metagraph, will commit when registered")
+            
+        # Start periodic fetching
+        self.start_commitment_fetcher()
+```
+
+### 3. Integration Points
+
+#### Miner Integration (`grail/cli/mine.py`)
+```python
+def mine(...):
+    # Load credentials from environment
+    credentials = load_r2_credentials()
+    
+    # Initialize chain manager
+    chain_manager = GrailChainManager(config, wallet, credentials)
+    await chain_manager.initialize()
+    
+    # Use write credentials for uploading rollouts
+    async with get_client_ctx(credentials.write_credentials) as client:
+        # Upload rollout data
+        ...
+    
+    # Share bucket info for validators to read
+    # (This happens automatically via chain_manager.initialize())
+```
+
+#### Validator Integration (`grail/cli/validate.py`)
+```python
+def validate(...):
+    # Load local write credentials
+    credentials = load_r2_credentials()
+    
+    # Initialize chain manager
+    chain_manager = GrailChainManager(config, wallet, credentials)
+    await chain_manager.initialize()
+    
+    # Fetch miner read credentials from chain
+    miner_buckets = chain_manager.get_all_buckets()
+    
+    for uid, read_creds in miner_buckets.items():
+        if read_creds:
+            # Use miner's read credentials to fetch their rollouts
+            async with get_client_ctx(read_creds) as client:
+                # Download and validate rollouts
+                ...
+```
+
+### 4. Credential Loading
+
+#### Environment Variable Structure
+```bash
+# Shared configuration (same for read and write)
+R2_BUCKET_ID=<your_bucket_name>
+R2_ACCOUNT_ID=<your_account_id>
+
+# Read-only credentials (will be shared on chain)
+R2_READ_ACCESS_KEY_ID=<your_read_only_key>
+R2_READ_SECRET_ACCESS_KEY=<your_read_only_secret>
+
+# Read-write credentials (local only, never shared)
+R2_WRITE_ACCESS_KEY_ID=<your_write_key>
+R2_WRITE_SECRET_ACCESS_KEY=<your_write_secret>
+```
+
+#### Credential Loader
+```python
+# grail/infrastructure/credentials.py
+def load_r2_credentials() -> BucketCredentials:
+    """Load R2 credentials from environment variables"""
+    # Same bucket and account for both read and write
+    bucket_id = get_conf("R2_BUCKET_ID")
+    account_id = get_conf("R2_ACCOUNT_ID")
+    
+    return BucketCredentials(
+        # Shared bucket configuration
+        bucket_name=bucket_id,
+        account_id=account_id,
+        
+        # Read-only credentials (to be shared on chain)
+        read_access_key_id=get_conf("R2_READ_ACCESS_KEY_ID"),
+        read_secret_access_key=get_conf("R2_READ_SECRET_ACCESS_KEY"),
+        
+        # Read-write credentials (private, never shared)
+        write_access_key_id=get_conf("R2_WRITE_ACCESS_KEY_ID"),
+        write_secret_access_key=get_conf("R2_WRITE_SECRET_ACCESS_KEY"),
+    )
+```
+
+### 5. Modified Communication Layer
+
+#### Updated S3 Client Context
+```python
+# grail/infrastructure/comms.py
+def get_client_ctx(credentials: Union[BucketCredentials, dict], use_write: bool = True):
+    """Create S3 client with specified credentials
+    
+    Args:
+        credentials: Either BucketCredentials object or dict with credential fields
+        use_write: If True and credentials is BucketCredentials, use write creds
+    """
+    if isinstance(credentials, BucketCredentials):
+        # Same account and bucket, different access keys
+        account_id = credentials.account_id
+        bucket_name = credentials.bucket_name
+        if use_write:
+            access_key = credentials.write_access_key_id
+            secret_key = credentials.write_secret_access_key
+        else:
+            access_key = credentials.read_access_key_id
+            secret_key = credentials.read_secret_access_key
+    else:
+        # Handle dict format (from chain commitments)
+        account_id = credentials['account_id']
+        access_key = credentials['access_key_id']
+        secret_key = credentials['secret_access_key']
+    
+    endpoint_url = f"https://{account_id}.r2.cloudflarestorage.com"
+    
+    return get_session().create_client(
+        "s3",
+        endpoint_url=endpoint_url,
+        aws_access_key_id=access_key,
+        aws_secret_access_key=secret_key,
+        config=Config(...)
+    )
+```
+
+## Implementation Plan
+
+### Phase 1: Core Infrastructure
+1. Create `grail/infrastructure/chain.py` with `GrailChainManager` class
+2. Add `BucketCredentials` schema to `grail/shared/schemas.py`
+3. Create `grail/infrastructure/credentials.py` for credential loading
+4. Update `grail/infrastructure/comms.py` to support dual credentials
+
+### Phase 2: Miner Integration
+1. Modify `grail/cli/mine.py` to:
+   - Load dual credentials on startup
+   - Initialize chain manager and commit read credentials
+   - Use write credentials for uploading rollouts
+2. Update rollout upload functions to use write credentials
+
+### Phase 3: Validator Integration
+1. Modify `grail/cli/validate.py` to:
+   - Load local write credentials
+   - Fetch miner read credentials from chain
+   - Use appropriate credentials for reading miner rollouts
+2. Update validation logic to handle per-miner bucket access
+
+### Phase 4: Testing & Migration
+1. Add unit tests for credential management
+2. Add integration tests for chain commitment/retrieval
+3. Create migration guide for existing deployments
+4. Update documentation with new environment variables
+
+## Security Considerations
+
+1. **Credential Isolation**: Write credentials must NEVER be committed to chain
+2. **Validation**: Always verify signatures on chain commitments
+3. **Access Control**: Ensure read credentials have minimal permissions (read-only)
+4. **Rotation**: Design should support credential rotation without breaking validation
+5. **Error Handling**: Graceful fallback if chain commitments are unavailable
+
+## Backwards Compatibility
+
+To maintain compatibility during migration:
+1. Check for new environment variables first
+2. Fall back to old single-credential system if new vars not found
+3. Log warnings about deprecated configuration
+4. Provide clear migration timeline
+
+## Benefits
+
+1. **Security**: Write credentials remain private while sharing read-only access
+2. **Simplicity**: Single bucket and account simplifies management
+3. **Transparency**: Validators can verify miner data availability
+4. **Decentralization**: No central authority needed for data access
+5. **Auditability**: All participants can verify rollout data
+6. **Cost Efficiency**: Single bucket reduces storage costs and complexity
+
+## Future Extensions
+
+1. **Multi-provider Support**: Allow different miners to use different storage providers
+2. **Credential Rotation**: Automated rotation with grace period
+3. **Access Analytics**: Track who's reading whose data
+4. **Compression Negotiation**: Advertise supported compression formats in commitments
+5. **Replication**: Support multiple read endpoints for redundancy

--- a/grail/cli/validate.py
+++ b/grail/cli/validate.py
@@ -34,6 +34,8 @@ from ..infrastructure.comms import (
     login_huggingface,
     PROTOCOL_VERSION,
 )
+from ..infrastructure.credentials import load_r2_credentials
+from ..infrastructure.chain import GrailChainManager
 from ..shared.constants import NETUID, WINDOW_LENGTH, MODEL_NAME, SUPERLINEAR_EXPONENT
 from ..monitoring import get_monitoring_manager
 from ..monitoring.config import MonitoringConfig
@@ -223,6 +225,21 @@ def validate(
     async def _run() -> None:
         subtensor = None
         
+        # Load R2 credentials
+        try:
+            credentials = load_r2_credentials()
+            logger.info("✅ Loaded R2 credentials")
+        except Exception as e:
+            logger.error(f"Failed to load R2 credentials: {e}")
+            raise
+        
+        # Initialize chain manager for credential commitments
+        config = bt.config()
+        config.netuid = NETUID
+        chain_manager = GrailChainManager(config, wallet, credentials)
+        await chain_manager.initialize()
+        logger.info("✅ Initialized chain manager and committed read credentials")
+        
         # Initialize monitoring for validation operations
         monitor = get_monitoring_manager()
         if monitor:
@@ -325,8 +342,12 @@ def validate(
                         # Construct expected filename for this hotkey and window
                         filename = f"grail/windows/{wallet_addr}-window-{target_window}.json"
 
+                        # Get miner's read credentials from chain
+                        miner_bucket = chain_manager.get_bucket_for_hotkey(wallet_addr)
+                        
                         # Check if file exists before downloading
-                        exists = await file_exists(filename)
+                        # Use miner's read credentials if available, otherwise use our own
+                        exists = await file_exists(filename, credentials=miner_bucket if miner_bucket else credentials, use_write=False)
                         if not exists:
                             logger.debug(f"No file found for {wallet_addr} at {filename}")
                             continue
@@ -334,7 +355,8 @@ def validate(
                         files_found += 1
                         logger.info(f"📁 Found file for hotkey {wallet_addr}")
 
-                        window_data = await get_file(filename)
+                        # Download using appropriate credentials
+                        window_data = await get_file(filename, credentials=miner_bucket if miner_bucket else credentials, use_write=False)
                         if not window_data:
                             logger.warning(f"Could not download {filename}")
                             continue
@@ -755,7 +777,7 @@ def validate(
                 # Upload all valid rollouts for training and to Hugging Face
                 if all_valid_rollouts:
                     # Upload to S3/R2 for immediate access
-                    upload_success = await upload_valid_rollouts(target_window, all_valid_rollouts)
+                    upload_success = await upload_valid_rollouts(target_window, all_valid_rollouts, credentials)
                     if upload_success:
                         logger.info(
                             f"📤 Uploaded {len(all_valid_rollouts)} valid rollouts for training"

--- a/grail/infrastructure/chain.py
+++ b/grail/infrastructure/chain.py
@@ -1,0 +1,280 @@
+"""GRAIL-specific chain manager for R2 credentials management."""
+
+import asyncio
+import logging
+from typing import Optional, Dict
+from pydantic import ValidationError
+
+import bittensor as bt
+from bittensor.core.chain_data import decode_account_id
+
+from ..shared.schemas import BucketCredentials, Bucket
+
+logger = logging.getLogger(__name__)
+
+
+class GrailChainManager:
+    """GRAIL-specific chain manager for handling R2 credential commitments"""
+    
+    def __init__(
+        self,
+        config,
+        wallet: bt.wallet,
+        credentials: BucketCredentials,
+        fetch_interval: int = 600,  # 10 minutes default
+    ):
+        """
+        Initialize GRAIL chain manager.
+        
+        Args:
+            config: Bittensor config object
+            wallet: Wallet for signing commitments
+            credentials: Dual R2 credentials
+            fetch_interval: Interval in seconds between fetching commitments
+        """
+        self.config = config
+        self.netuid = config.netuid
+        self.wallet = wallet
+        self.credentials = credentials
+        self.fetch_interval = fetch_interval
+        
+        # Initialize Bittensor objects
+        self.subtensor = bt.subtensor(config=config)
+        self.metagraph = self.subtensor.metagraph(self.netuid)
+        
+        # Commitment tracking
+        self.commitments: Dict[int, Bucket] = {}
+        self._fetch_task: Optional[asyncio.Task] = None
+        
+        logger.info(f"Initialized GrailChainManager for netuid {self.netuid}")
+    
+    async def initialize(self):
+        """Initialize chain manager and verify/commit credentials"""
+        logger.info("Initializing GRAIL chain manager...")
+        
+        # Fetch existing commitments
+        await self.fetch_commitments()
+        
+        # Check if our commitment matches what's on chain
+        try:
+            uid = self.metagraph.hotkeys.index(self.wallet.hotkey.ss58_address)
+            existing = self.commitments.get(uid)
+            
+            # Compare existing commitment with our read credentials
+            our_commitment = self._create_bucket_from_read_creds()
+            
+            if not existing or not self._commitments_match(existing, our_commitment):
+                if not existing:
+                    logger.info("No existing commitment found, committing read credentials to chain")
+                else:
+                    logger.info("Commitment mismatch, updating read credentials on chain")
+                self.commit_read_credentials()
+            else:
+                logger.info("Existing commitment matches current read credentials")
+                
+        except ValueError:
+            logger.warning(f"Hotkey {self.wallet.hotkey.ss58_address} not found in metagraph, will commit when registered")
+        
+        # Start periodic fetching
+        self.start_commitment_fetcher()
+    
+    def _create_bucket_from_read_creds(self) -> Bucket:
+        """Create a Bucket object from read credentials for comparison"""
+        return Bucket(
+            name=self.credentials.bucket_name[:32].ljust(32),
+            account_id=self.credentials.account_id[:32].ljust(32),
+            access_key_id=self.credentials.read_access_key_id[:32].ljust(32),
+            secret_access_key=self.credentials.read_secret_access_key[:64].ljust(64),
+        )
+    
+    def _commitments_match(self, bucket1: Bucket, bucket2: Bucket) -> bool:
+        """Check if two bucket commitments match"""
+        return (
+            bucket1.name.strip() == bucket2.name.strip() and
+            bucket1.access_key_id.strip() == bucket2.access_key_id.strip() and
+            bucket1.secret_access_key.strip() == bucket2.secret_access_key.strip()
+        )
+    
+    def commit_read_credentials(self):
+        """Commit read credentials to the chain"""
+        commitment = self.credentials.read_commitment
+        
+        if self.netuid is not None:
+            try:
+                self.subtensor.commit(self.wallet, self.netuid, commitment)
+                logger.info(
+                    f"Successfully committed read credentials to chain for hotkey {self.wallet.hotkey.ss58_address}"
+                )
+            except Exception as e:
+                logger.error(f"Failed to commit read credentials: {e}")
+                # Try to reinitialize substrate connection
+                self.subtensor.substrate.close()
+                self.subtensor.substrate.initialize()
+                raise
+    
+    def start_commitment_fetcher(self):
+        """Start background task to periodically fetch commitments"""
+        if self._fetch_task is None:
+            self._fetch_task = asyncio.create_task(self._fetch_commitments_periodically())
+            logger.info(f"Started commitment fetcher with {self.fetch_interval}s interval")
+    
+    async def _fetch_commitments_periodically(self):
+        """Background task to periodically fetch commitments"""
+        while True:
+            try:
+                await asyncio.sleep(self.fetch_interval)
+                
+                # Sync metagraph
+                await asyncio.to_thread(
+                    lambda: self.metagraph.sync(subtensor=self.subtensor)
+                )
+                
+                # Fetch commitments
+                await self.fetch_commitments()
+                
+            except Exception as e:
+                logger.error(f"Error in periodic commitment fetch: {e}")
+                # Try to reinitialize substrate connection
+                try:
+                    self.subtensor.substrate.close()
+                    self.subtensor.substrate.initialize()
+                except:
+                    pass
+    
+    async def fetch_commitments(self):
+        """Fetch all bucket commitments from the chain"""
+        try:
+            commitments = await self.get_commitments()
+            if commitments:
+                self.commitments = commitments
+                logger.debug(f"Fetched {len(commitments)} commitments from chain")
+            else:
+                logger.warning("No commitments fetched from chain")
+        except Exception as e:
+            logger.error(f"Failed to fetch commitments: {e}")
+    
+    async def get_commitments(self, block: Optional[int] = None) -> Dict[int, Bucket]:
+        """
+        Retrieve all bucket commitments from the chain.
+        
+        Args:
+            block: Optional block number to query at
+            
+        Returns:
+            Dictionary mapping UIDs to Bucket configurations
+        """
+        try:
+            substrate = self.subtensor.substrate
+            
+            # Query commitments via substrate
+            query_result = substrate.query_map(
+                module="Commitments",
+                storage_function="CommitmentOf",
+                params=[self.netuid],
+                block_hash=None if block is None else substrate.get_block_hash(block),
+            )
+            
+            # Create hotkey to UID mapping
+            hotkey_to_uid = dict(zip(self.metagraph.hotkeys, self.metagraph.uids))
+            commitments = {}
+            
+            for key, value in query_result:
+                try:
+                    # Decode the commitment
+                    decoded_ss58, commitment_str = self._decode_metadata(key, value.value)
+                except Exception as e:
+                    logger.error(f"Failed to decode metadata for key {key.value}: {e}")
+                    continue
+                
+                # Skip if hotkey not in metagraph
+                if decoded_ss58 not in hotkey_to_uid:
+                    continue
+                
+                uid = hotkey_to_uid[decoded_ss58]
+                
+                # Validate commitment length
+                if len(commitment_str) != 128:
+                    logger.error(
+                        f"Invalid commitment length for UID {uid}: {len(commitment_str)}"
+                    )
+                    continue
+                
+                try:
+                    # Parse commitment into Bucket
+                    bucket = Bucket(
+                        name=commitment_str[:32],
+                        account_id=commitment_str[:32],  # Same as name for compatibility
+                        access_key_id=commitment_str[32:64],
+                        secret_access_key=commitment_str[64:],
+                    )
+                    commitments[uid] = bucket
+                    logger.debug(f"Retrieved bucket commitment for UID {uid}")
+                    
+                except ValidationError as e:
+                    logger.error(f"Failed to validate bucket for UID {uid}: {e}")
+                    continue
+            
+            return commitments
+            
+        except Exception as e:
+            logger.error(f"Error querying commitments from chain: {e}")
+            # Try to reinitialize substrate connection
+            self.subtensor.substrate.close()
+            self.subtensor.substrate.initialize()
+            return {}
+    
+    def _decode_metadata(self, encoded_ss58: tuple, metadata: dict) -> tuple[str, str]:
+        """Decode metadata from chain query result"""
+        # Decode the key into an SS58 address
+        decoded_key = decode_account_id(encoded_ss58[0])
+        
+        # Get the commitment from the metadata
+        commitment = metadata["info"]["fields"][0][0]
+        bytes_tuple = commitment[next(iter(commitment.keys()))][0]
+        
+        return decoded_key, bytes(bytes_tuple).decode()
+    
+    def get_bucket(self, uid: int) -> Optional[Bucket]:
+        """
+        Get the bucket configuration for a given UID.
+        
+        Args:
+            uid: The UID to retrieve the bucket for
+            
+        Returns:
+            Bucket configuration or None if not found
+        """
+        return self.commitments.get(uid)
+    
+    def get_all_buckets(self) -> Dict[int, Optional[Bucket]]:
+        """
+        Get all bucket configurations for all UIDs.
+        
+        Returns:
+            Dictionary mapping UIDs to their bucket configurations
+        """
+        return {uid: self.get_bucket(uid) for uid in self.metagraph.uids}
+    
+    def get_bucket_for_hotkey(self, hotkey: str) -> Optional[Bucket]:
+        """
+        Get bucket configuration for a specific hotkey.
+        
+        Args:
+            hotkey: SS58 address of the hotkey
+            
+        Returns:
+            Bucket configuration or None if not found
+        """
+        try:
+            uid = self.metagraph.hotkeys.index(hotkey)
+            return self.get_bucket(uid)
+        except ValueError:
+            logger.warning(f"Hotkey {hotkey} not found in metagraph")
+            return None
+    
+    def stop(self):
+        """Stop the background fetcher task"""
+        if self._fetch_task:
+            self._fetch_task.cancel()
+            self._fetch_task = None
+            logger.info("Stopped commitment fetcher")

--- a/grail/infrastructure/credentials.py
+++ b/grail/infrastructure/credentials.py
@@ -1,0 +1,167 @@
+"""Credential loading utilities for GRAIL R2 integration."""
+
+import os
+import logging
+from typing import Optional
+
+from ..shared.schemas import BucketCredentials
+
+logger = logging.getLogger(__name__)
+
+
+def get_conf(key: str, default: Optional[str] = None) -> str:
+    """
+    Get configuration from environment variables.
+    
+    Args:
+        key: Environment variable key
+        default: Default value if not set
+        
+    Returns:
+        Configuration value
+        
+    Raises:
+        ValueError: If required key is not set and no default provided
+    """
+    value = os.getenv(key)
+    if not value and default is None:
+        raise ValueError(f"{key} not set. Please set the environment variable.")
+    return value or default or ""
+
+
+def load_r2_credentials(fallback_to_single: bool = True) -> BucketCredentials:
+    """
+    Load R2 credentials from environment variables.
+    
+    Supports both dual-credential mode (separate read/write keys for same bucket) 
+    and backwards-compatible single-credential mode.
+    
+    Args:
+        fallback_to_single: If True, fall back to single credential mode
+                          if dual credentials are not found
+    
+    Returns:
+        BucketCredentials object with read and write credentials
+        
+    Raises:
+        ValueError: If required credentials are not found
+    """
+    # Try to load dual credentials first
+    try:
+        logger.info("Attempting to load dual R2 credentials...")
+        
+        # Same bucket and account for both read and write
+        bucket_id = get_conf("R2_BUCKET_ID")
+        account_id = get_conf("R2_ACCOUNT_ID")
+        
+        credentials = BucketCredentials(
+            # Shared bucket configuration
+            bucket_name=bucket_id,
+            account_id=account_id,
+            
+            # Read-only credentials (to be shared on chain)
+            read_access_key_id=get_conf("R2_READ_ACCESS_KEY_ID"),
+            read_secret_access_key=get_conf("R2_READ_SECRET_ACCESS_KEY"),
+            
+            # Read-write credentials (private, never shared)
+            write_access_key_id=get_conf("R2_WRITE_ACCESS_KEY_ID"),
+            write_secret_access_key=get_conf("R2_WRITE_SECRET_ACCESS_KEY"),
+        )
+        
+        logger.info(f"Successfully loaded dual R2 credentials for bucket: {bucket_id}")
+        return credentials
+        
+    except ValueError as e:
+        if not fallback_to_single:
+            raise
+        
+        logger.warning(f"Dual credentials not found: {e}")
+        logger.info("Falling back to single credential mode (backwards compatibility)")
+    
+    # Fall back to single credential mode for backwards compatibility
+    try:
+        # Load single set of credentials
+        account_id = get_conf("R2_ACCOUNT_ID")
+        access_key = get_conf("R2_WRITE_ACCESS_KEY_ID")
+        secret_key = get_conf("R2_WRITE_SECRET_ACCESS_KEY")
+        bucket_id = get_conf("R2_BUCKET_ID")
+        
+        # Use the same credentials for both read and write
+        credentials = BucketCredentials(
+            # Shared bucket configuration
+            bucket_name=bucket_id,
+            account_id=account_id,
+            
+            # Use write credentials for read (backwards compatibility)
+            read_access_key_id=access_key,
+            read_secret_access_key=secret_key,
+            
+            # Write credentials
+            write_access_key_id=access_key,
+            write_secret_access_key=secret_key,
+        )
+        
+        logger.warning(
+            "Using single credential mode (deprecated). "
+            "Please migrate to dual credentials for improved security. "
+            "Set R2_READ_ACCESS_KEY_ID, R2_READ_SECRET_ACCESS_KEY, "
+            "R2_WRITE_ACCESS_KEY_ID, and R2_WRITE_SECRET_ACCESS_KEY environment variables."
+        )
+        
+        return credentials
+        
+    except ValueError as e:
+        logger.error(
+            "Failed to load R2 credentials. Please set either:\n"
+            "1. Dual credentials: R2_BUCKET_ID, R2_ACCOUNT_ID, "
+            "R2_READ_ACCESS_KEY_ID, R2_READ_SECRET_ACCESS_KEY, "
+            "R2_WRITE_ACCESS_KEY_ID, R2_WRITE_SECRET_ACCESS_KEY\n"
+            "2. Single credentials (deprecated): R2_BUCKET_ID, R2_ACCOUNT_ID, "
+            "R2_WRITE_ACCESS_KEY_ID, R2_WRITE_SECRET_ACCESS_KEY"
+        )
+        raise ValueError(f"Failed to load R2 credentials: {e}") from e
+
+
+def validate_credentials(credentials: BucketCredentials) -> bool:
+    """
+    Validate that credentials have required fields.
+    
+    Args:
+        credentials: Credentials to validate
+        
+    Returns:
+        True if valid, False otherwise
+    """
+    try:
+        # Check shared configuration
+        if not all([credentials.bucket_name, credentials.account_id]):
+            logger.error("Missing bucket name or account ID")
+            return False
+        
+        # Check read credentials
+        if not all([
+            credentials.read_access_key_id,
+            credentials.read_secret_access_key,
+        ]):
+            logger.error("Missing required read credentials")
+            return False
+        
+        # Check write credentials
+        if not all([
+            credentials.write_access_key_id,
+            credentials.write_secret_access_key,
+        ]):
+            logger.error("Missing required write credentials")
+            return False
+        
+        # Validate commitment length
+        commitment = credentials.read_commitment
+        if len(commitment) != 128:
+            logger.error(f"Invalid commitment length: {len(commitment)} (expected 128)")
+            return False
+        
+        return True
+        
+    except Exception as e:
+        logger.error(f"Error validating credentials: {e}")
+        return False

--- a/grail/shared/schemas.py
+++ b/grail/shared/schemas.py
@@ -1,0 +1,80 @@
+"""Data schemas for GRAIL R2 credentials management."""
+
+from typing import Optional
+from pydantic import BaseModel, Field, ConfigDict
+
+
+class BucketCredentials(BaseModel):
+    """Dual credential configuration for R2 buckets
+    
+    Same bucket and account, but different access keys:
+    - Read credentials: read-only access (shared on chain)
+    - Write credentials: read-write access (kept private)
+    """
+    
+    # Shared bucket configuration
+    bucket_name: str = Field(..., min_length=1)
+    account_id: str = Field(..., min_length=1)
+    
+    # Read-only credentials (shared on chain)
+    read_access_key_id: str = Field(..., min_length=1)
+    read_secret_access_key: str = Field(..., min_length=1)
+    
+    # Read-write credentials (local only, never shared)
+    write_access_key_id: str = Field(..., min_length=1)
+    write_secret_access_key: str = Field(..., min_length=1)
+    
+    model_config = ConfigDict(
+        str_strip_whitespace=True,
+    )
+    
+    @property
+    def read_commitment(self) -> str:
+        """Generate commitment string for chain (128 chars total)"""
+        # Truncate/pad to exactly 32 chars each for 128 total
+        return (
+            self.bucket_name[:32].ljust(32) +
+            self.read_access_key_id[:32].ljust(32) +
+            self.read_secret_access_key[:64].ljust(64)
+        )
+    
+    def get_read_dict(self) -> dict:
+        """Get read credentials as dict for compatibility"""
+        return {
+            "name": self.bucket_name,
+            "account_id": self.account_id,
+            "access_key_id": self.read_access_key_id,
+            "secret_access_key": self.read_secret_access_key,
+        }
+    
+    def get_write_dict(self) -> dict:
+        """Get write credentials as dict for compatibility"""
+        return {
+            "name": self.bucket_name,
+            "account_id": self.account_id,
+            "access_key_id": self.write_access_key_id,
+            "secret_access_key": self.write_secret_access_key,
+        }
+
+
+class Bucket(BaseModel):
+    """Configuration for a bucket (used for chain commitments)"""
+    
+    def __hash__(self):
+        return hash(
+            (self.name, self.account_id, self.access_key_id, self.secret_access_key)
+        )
+    
+    def __eq__(self, other):
+        if isinstance(other, Bucket):
+            return self.model_dump() == other.model_dump()
+        return False
+    
+    name: str = Field(..., min_length=1)
+    account_id: str = Field(..., min_length=1)
+    access_key_id: str = Field(..., min_length=1)
+    secret_access_key: str = Field(..., min_length=1)
+    
+    model_config = ConfigDict(
+        str_strip_whitespace=True,
+    )

--- a/schema.py
+++ b/schema.py
@@ -1,0 +1,65 @@
+# The MIT License (MIT)
+# © 2025 tplr.ai
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+# documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+# and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+# the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+# THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+# OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+# DEALINGS IN THE SOFTWARE.
+
+# Global imports
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class Bucket(BaseModel):
+    """Configuration for a bucket, including name and access credentials."""
+
+    def __hash__(self):
+        # Use all fields to generate a unique hash
+        return hash(
+            (self.name, self.account_id, self.access_key_id, self.secret_access_key)
+        )
+
+    def __eq__(self, other):
+        # Compare all fields to determine equality
+        if isinstance(other, Bucket):
+            return self.model_dump() == other.model_dump()
+        return False
+
+    name: str = Field(..., min_length=1)
+    account_id: str = Field(..., min_length=1)
+    access_key_id: str = Field(..., min_length=1)
+    secret_access_key: str = Field(..., min_length=1)
+
+    model_config = ConfigDict(
+        str_strip_whitespace=True,
+    )
+
+
+class CommsGetResult(BaseModel):
+    """A standard return type for the `get` function."""
+
+    data: None | dict[str, Any] = Field(
+        None, description="The data retrieved by the get function."
+    )
+    global_step: None | int = Field(
+        None, description="The global step associated with the data."
+    )
+    status: Literal["OK", "TOO_EARLY", "TOO_LATE", "NOT_FOUND", "ERROR"] = Field(
+        "OK", description="The status of the get operation."
+    )
+
+    @property
+    def success(self) -> bool:
+        """Returns True if the operation was successful and returned data."""
+        return self.status == "OK" and self.data is not None


### PR DESCRIPTION
- Add BucketCredentials schema for managing read/write credentials
- Implement GrailChainManager for posting read credentials to chain
- Add credential loader with backwards compatibility
- Update comms layer to support dual credentials
- Integrate chain manager into miner and validator CLIs
- Support same bucket/account with different access keys
- Maintain backwards compatibility with single credential mode

This allows miners/validators to:
- Share read-only credentials on chain for transparency
- Keep write credentials private for security
- Use the same bucket with different access levels