### PR TITLE
make mount not RO

### DIFF
--- a/docker/docker-compose.validator.yml
+++ b/docker/docker-compose.validator.yml
@@ -56,7 +56,7 @@ services:
 
     volumes:
       # Persistent storage for wallet and cache
-      - ${HOME}/.bittensor:/root/.bittensor:ro
+      - ${HOME}/.bittensor:/root/.bittensor
       - validator-cache:/root/.cache
       - validator-data:/app/data
       


### PR DESCRIPTION
If you do want it RO I can update the PR with a README change to validators instead to mkdir the miner folder

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Validator container now has write access to the local Bittensor data directory, enabling it to persist updates (e.g., keys, configs, checkpoints) and reducing permission-related errors.
- Style
  - Minor formatting cleanup in configuration; no behavioral impact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->